### PR TITLE
Add missing .js extension to import

### DIFF
--- a/src/input_builder.js
+++ b/src/input_builder.js
@@ -1,4 +1,4 @@
-import { InvalidInputsError } from "./error";
+import { InvalidInputsError } from './error.js';
 
 export default function(name, value) {
     function get() {


### PR DESCRIPTION
Add a missing .js extension to a VS-code-auto-generated import in
input_builder.js.
