### PR TITLE
Fix some fatal errors

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -4,9 +4,23 @@ import path from 'path';
 import process from 'process';
 import { wrapGuruMarkdown } from './api_util.js';
 import prepare from './prepare.js';
+import createApi from './api.js';
 
 export default async function(options) {
-    const api = options.api;
+    options.logger ||= {
+        debug() {},
+
+        isDebug() {
+            return false;
+        }
+    };
+
+    const api = createApi(options.client, {
+        endpoint: options.guruEndpoint,
+        userEmail: options.userEmail,
+        userToken: options.userToken,
+        logger: options.logger
+    });
 
     async function getNewLocalImageUrl(url) {
         const parentDir = path.dirname(options.filePath);

--- a/src/api_client.js
+++ b/src/api_client.js
@@ -1,4 +1,6 @@
-export default function(fetch, options) {
+import { FormData } from "node-fetch";
+
+export default function(fetch, options = {}) {
     const baseEndpoint = options.endpoint || 'https://api.getguru.com/api/v1/';
 
     function endpoint(path = null) {
@@ -31,7 +33,7 @@ export default function(fetch, options) {
         const formData = new FormData();
         formData.append('file', blob, fileName);
 
-        options.data = options.data || formData;
+        options.body = options.body || formData;
 
         return await fetch('POST', endpoint(`attachments/upload`), options);
     }

--- a/src/inputs.js
+++ b/src/inputs.js
@@ -13,6 +13,7 @@ export default function(getCoreInput) {
         collectionId: input('collection_id').required().get(),
         boardId: input('board_id').get(),
         boardSectionId: input('board_section_id').get(),
-        cardFooter: input('card_footer').get()
+        cardFooter: input('card_footer').get(),
+        debugLogging: input('debug_logging').fallback('false').boolean().get()
     };
 }

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -4,18 +4,6 @@ import { FetchError } from '../src/error.js';
 import createClient from './support/api_client.js';
 import { resource } from './support/util.js';
 
-function createApi(client) {
-    return baseCreateApi(client, {
-        logger: {
-            debug() {},
-
-            isDebug() {
-                return false;
-            }
-        }
-    });
-}
-
 test('creates new card in collection if none exists', async() => {
     const client = createClient({
         searchResult: {
@@ -34,7 +22,7 @@ test('creates new card in collection if none exists', async() => {
     });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card.md',
         cardTitle: 'Test Card',
         collectionId: 'c123'
@@ -84,7 +72,7 @@ test('creates new card in board if none exists', async() => {
     });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card.md',
         cardTitle: 'Test Card',
         collectionId: 'c123',
@@ -140,7 +128,7 @@ test('creates new card in board section if none exists', async() => {
     });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card.md',
         cardTitle: 'Test Card',
         collectionId: 'c123',
@@ -199,7 +187,7 @@ test('updates existing card in collection', async() => {
     });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card.md',
         cardTitle: 'Test Card',
         collectionId: 'c123'
@@ -254,7 +242,7 @@ test('updates existing card in board', async() => {
     });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card.md',
         cardTitle: 'Test Card',
         collectionId: 'c123',
@@ -315,7 +303,7 @@ test('updates existing card in board section', async() => {
     });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card.md',
         cardTitle: 'Test Card',
         collectionId: 'c123',
@@ -349,7 +337,7 @@ test('uploads local images', async() => {
     });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card_with_local_image.md',
         cardTitle: 'Local Image',
         collectionId: 'c123',
@@ -375,7 +363,7 @@ test('with string card footer appends it', async() => {
     const client = createClient({ searchResult: { cards: [] } });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card.md',
         cardTitle: 'Test Card',
         collectionId: 'c123',
@@ -392,7 +380,7 @@ test.each([[true], [undefined], ['']])('with true or undefined or blank card foo
     const client = createClient({ searchResult: { cards: [] } });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card.md',
         cardTitle: 'Test Card',
         collectionId: 'c123',
@@ -410,7 +398,7 @@ test('with no card footer given appends default', async() => {
     const client = createClient({ searchResult: { cards: [] } });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card.md',
         cardTitle: 'Test Card',
         collectionId: 'c123',
@@ -432,7 +420,7 @@ test.each([
     const client = createClient({ searchResult: { cards: [] } });
 
     await action({
-        api: createApi(client),
+        client,
         filePath: 'test/resources/test_card.md',
         cardTitle: 'Test Card',
         collectionId: 'c123',
@@ -470,7 +458,7 @@ test('with failed server JSON response throws proper error', async() => {
 
     try {
         response = await action({
-            api: createApi(client),
+            client,
             filePath: 'test/resources/test_card.md',
             cardTitle: 'Test Card',
             collectionId: 'c123'
@@ -513,7 +501,7 @@ test('with failed server text response throws proper error', async() => {
 
     try {
         response = await action({
-            api: createApi(client),
+            client,
             filePath: 'test/resources/test_card.md',
             cardTitle: 'Test Card',
             collectionId: 'c123'
@@ -556,7 +544,7 @@ test('with null server response throws proper error', async() => {
 
     try {
         response = await action({
-            api: createApi(client),
+            client,
             filePath: 'test/resources/test_card.md',
             cardTitle: 'Test Card',
             collectionId: 'c123'
@@ -599,7 +587,7 @@ test('with non-JSON server response throws proper error', async() => {
 
     try {
         response = await action({
-            api: createApi(client),
+            client,
             filePath: 'test/resources/test_card.md',
             cardTitle: 'Test Card',
             collectionId: 'c123'

--- a/test/inputs.test.js
+++ b/test/inputs.test.js
@@ -83,3 +83,25 @@ test('card_footer is not required', () => {
     const actual = getInputs(name => name === 'card_footer' ? '' : getInput(name)).cardFooter;
     expect(actual).toBe(null);
 });
+
+describe('debugLogging', () => {
+    test('is not required and has default', () => {
+        const actual = getInputs(name => name === 'debug_logging' ? '' : getInput(name)).debugLogging;
+        expect(actual).toBe(false);
+    });
+
+    test('with true', () => {
+        const actual = getInputs(name => name === 'debug_logging' ? 'true' : getInput(name)).debugLogging;
+        expect(actual).toBe(true);
+    });
+
+    test('with false', () => {
+        const actual = getInputs(name => name === 'debug_logging' ? 'false' : getInput(name)).debugLogging;
+        expect(actual).toBe(false);
+    });
+
+    test('with something else throws error', () => {
+        const f = () => getInputs(name => name === 'debug_logging' ? 'invalid' : getInput(name)).debugLogging;
+        expect(f).toThrow(InvalidInputsError);
+    });
+});


### PR DESCRIPTION
Fix some fatal errors in index.js.

  - missing import in api_client.js
  - missing default options value in api_client.js
  - deprecated property in api_client.js
  - faulty resource path in index.js (needed to use `import.meta.url`)

In the process, restructure several
things, including:
  - instantiate the api instance in action.js instead of index.js
  - add a debug_logging property for use with `act`, which I couldn't
get to use the normal debug logging property
