### PR TITLE
Fix duplicate cards

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -125,7 +125,7 @@ export default function(client, options) {
             body: JSON.stringify(options)
         });
 
-        return (await validate(response)).cards;
+        return (await validate(response));
     }
 
     async function getCardWith(title, collectionId, boardId = null, boardSectionId = null) {
@@ -137,9 +137,7 @@ export default function(client, options) {
         }
         else {
             cards = await searchCards({
-                collectionIds: [collectionId],
-                queryType: 'search_cards',
-                searchTerms: title
+                collectionIds: [collectionId]
             });
             cards = cards.filter(card => !card.boards || card.boards.length === 0);
         }

--- a/src/api_client.js
+++ b/src/api_client.js
@@ -26,7 +26,7 @@ export default function(fetch, options = {}) {
     }
 
     async function searchCards(options) {
-        return await fetch('POST', endpoint(`search/cards`), options);
+        return await fetch('POST', endpoint(`search/cardmgr`), options);
     }
 
     async function uploadAttachment(fileName, blob, options) {

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -1,24 +1,21 @@
 import action from '../src/action.js';
-import baseCreateApi from '../src/api.js';
 import { FetchError } from '../src/error.js';
 import createClient from './support/api_client.js';
 import { resource } from './support/util.js';
 
 test('creates new card in collection if none exists', async() => {
     const client = createClient({
-        searchResult: {
-            cards: [
-                {
-                    id: 'wrong-title',
-                    preferredPhrase: 'Wrong Title'
-                },
-                {
-                    id: 'in-board',
-                    preferredPhrase: 'Test Card',
-                    boards: [{ id: 'b123' }]
-                }
-            ]
-        }
+        searchResult: [
+            {
+                id: 'wrong-title',
+                preferredPhrase: 'Wrong Title'
+            },
+            {
+                id: 'in-board',
+                preferredPhrase: 'Test Card',
+                boards: [{ id: 'b123' }]
+            }
+        ]
     });
 
     await action({
@@ -166,24 +163,22 @@ test('creates new card in board section if none exists', async() => {
 
 test('updates existing card in collection', async() => {
     const client = createClient({
-        searchResult: {
-            cards: [
-                {
-                    id: 'wrong-title',
-                    preferredPhrase: 'Wrong Title'
-                },
-                {
-                    id: 'in-board',
-                    preferredPhrase: 'Test Card',
-                    boards: [{ id: 'b123' }]
-                },
-                {
-                    id: 'target',
-                    preferredPhrase: 'Test Card',
-                    boards: []
-                }
-            ]
-        }
+        searchResult: [
+            {
+                id: 'wrong-title',
+                preferredPhrase: 'Wrong Title'
+            },
+            {
+                id: 'in-board',
+                preferredPhrase: 'Test Card',
+                boards: [{ id: 'b123' }]
+            },
+            {
+                id: 'target',
+                preferredPhrase: 'Test Card',
+                boards: []
+            }
+        ]
     });
 
     await action({
@@ -332,7 +327,7 @@ test('updates existing card in board section', async() => {
 
 test('uploads local images', async() => {
     const client = createClient({
-        searchResult: { cards: [] },
+        searchResult: [],
         attachmentResult: { link: 'https://example.com/attachment.png' }
     });
 
@@ -360,7 +355,7 @@ test('uploads local images', async() => {
 });
 
 test('with string card footer appends it', async() => {
-    const client = createClient({ searchResult: { cards: [] } });
+    const client = createClient({ searchResult: [] });
 
     await action({
         client,
@@ -395,7 +390,7 @@ test.each([[true], [undefined], ['']])('with true or undefined or blank card foo
 });
 
 test('with no card footer given appends default', async() => {
-    const client = createClient({ searchResult: { cards: [] } });
+    const client = createClient({ searchResult: [] });
 
     await action({
         client,
@@ -417,7 +412,7 @@ test.each([
     [123],
     [123.45]
 ])('with any other non-string card footer does not append it', async(cardFooter) => {
-    const client = createClient({ searchResult: { cards: [] } });
+    const client = createClient({ searchResult: [] });
 
     await action({
         client,

--- a/test/action.test.js
+++ b/test/action.test.js
@@ -372,7 +372,7 @@ test('with string card footer appends it', async() => {
 });
 
 test.each([[true], [undefined], ['']])('with true or undefined or blank card footer appends default', async(cardFooter) => {
-    const client = createClient({ searchResult: { cards: [] } });
+    const client = createClient({ searchResult: [] });
 
     await action({
         client,


### PR DESCRIPTION
Fix duplicate cards appearing in Guru by switching the endpoint used to search for existing ones. It'll be much less efficient, however.
