### PR TITLE
Wrap the node response rather than cloning it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import action from './action.js';
 import { readFile } from './fs_util.js';
 import getInputs from './inputs.js';
 import createClient from './api_client.js';
+import wrapResponse from './wrap_response.js';
 
 async function main() {
     try {
@@ -29,11 +30,9 @@ async function main() {
             options.method = options.method || method;
             logger.debug(`Sending HTTP request to ${url} with options: ${JSON.stringify(options)}`);
 
-            const response = await nodeFetch(url, options);
+            const response = wrapResponse(await nodeFetch(url, options));
 
-            if(logger.isDebug()) {
-                logger.debug(`Received response from ${url}: ${await response.clone().text()}`);
-            }
+            logger.debug(`Received response from ${url}: ${await response.text()}`);
 
             return response;
         }

--- a/src/wrap_response.js
+++ b/src/wrap_response.js
@@ -1,0 +1,13 @@
+export default function(response) {
+    let text = null;
+
+    response.readTextFromStream = response.text;
+
+    response.text = async function() {
+        text ||= await response.readTextFromStream();
+
+        return text;
+    };
+
+    return response;
+}


### PR DESCRIPTION
For some reasons, cloning the node-fetch response caused obscure errors.
Instead, wrap the text() function so that it is only called once.
