### PR TITLE
Destroy cards when they are removed from config

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -106,6 +106,16 @@ export default function(client, options) {
         return await validate(response);
     }
 
+    async function destroyCard(id) {
+        logger.debug(`Destroying card with id ${id}`);
+
+        const response = await client.destroyCard(id, {
+            headers: headers()
+        });
+
+        return await validate(response);
+    }
+
     async function getCard(id) {
         logger.debug(`Getting card with id ${id}`);
 
@@ -133,6 +143,7 @@ export default function(client, options) {
     return {
         createCard,
         updateCard,
+        destroyCard,
         getCard,
         uploadAttachment
     };

--- a/src/api_client.js
+++ b/src/api_client.js
@@ -17,6 +17,10 @@ export default function(fetch, options = {}) {
         return await fetch('PUT', endpoint(`cards/${id}/extended`), options);
     }
 
+    async function destroyCard(id, options) {
+        return await fetch('DELETE', endpoint(`cards/${id}`), options);
+    }
+
     async function getCard(id, options) {
         return await fetch('GET', endpoint(`cards/${id}`), options);
     }
@@ -33,6 +37,7 @@ export default function(fetch, options = {}) {
     return {
         createCard,
         updateCard,
+        destroyCard,
         getCard,
         uploadAttachment
     };

--- a/test/support/api_client.js
+++ b/test/support/api_client.js
@@ -21,6 +21,18 @@ export default function(clientOptions = {}) {
         };
     }
 
+    function notFoundResponse() {
+        return {
+            ok: false,
+
+            status: 404,
+
+            text() {
+                return null;
+            }
+        };
+    }
+
     function createCard(options) {
         options.body = JSON.parse(options.body);
         calls.push({
@@ -44,6 +56,21 @@ export default function(clientOptions = {}) {
         return response(options);
     }
 
+    function destroyCard(id, options) {
+        calls.push({
+            type: 'destroyCard',
+            id,
+            options
+        });
+
+        if(call(clientOptions.destroyCardResult, id) === 'not_found') {
+            return notFoundResponse();
+        }
+        else {
+            return response(options);
+        }
+    }
+
     function getCard(id) {
         calls.push({
             type: 'getCard',
@@ -51,16 +78,8 @@ export default function(clientOptions = {}) {
         });
         const result = call(clientOptions.getCardResult, id);
 
-        if(result === null) {
-            return {
-                ok: false,
-
-                status: 404,
-
-                text() {
-                    return null;
-                }
-            };
+        if(result === 'not_found') {
+            return notFoundResponse();
         }
         else {
             return response(result);
@@ -82,6 +101,7 @@ export default function(clientOptions = {}) {
         getCalls,
         createCard,
         updateCard,
+        destroyCard,
         getCard,
         uploadAttachment
     };

--- a/test/support/array_logger.js
+++ b/test/support/array_logger.js
@@ -1,0 +1,24 @@
+export default function() {
+    const messages = [];
+
+    return {
+        debug(message) {
+            messages.push(message);
+        },
+        info(message) {
+            messages.push(message);
+        },
+        startGroup(name) {
+            messages.push('===' + name + '===');
+        },
+        endGroup() {
+            messages.push('=========');
+        },
+        isDebug() {
+            return true;
+        },
+        getMessages() {
+            return messages;
+        }
+    };
+}


### PR DESCRIPTION
Add the functionality to automatically destroy Guru cards that exist in
the cards file, but not in the workflow `cards` input.
