### PR TITLE
Update title as well as content

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "theguru",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/api.js
+++ b/src/api.js
@@ -98,6 +98,9 @@ export default function(client, options) {
     async function updateCard(id, options) {
         logger.debug(`Updating card with id ${id} with options ${JSON.stringify(options)}`);
 
+        options.preferredPhrase = options.title;
+        delete options.title;
+
         const response = await client.updateCard(id, {
             headers: headers(),
             body: JSON.stringify(options),

--- a/src/handle_card.js
+++ b/src/handle_card.js
@@ -31,9 +31,6 @@ export default async function(options) {
         await api.updateCard(existingCard.id, {
             ...existingCard,
             title: options.cardTitle,
-            collectionId: options.collectionId,
-            boardId: options.boardId,
-            sectionId: options.boardSectionId,
             content
         });
 

--- a/src/handle_card.js
+++ b/src/handle_card.js
@@ -30,6 +30,10 @@ export default async function(options) {
         logger.info(`Updating previously uploaded card ${cardId}`);
         await api.updateCard(existingCard.id, {
             ...existingCard,
+            title: options.cardTitle,
+            collectionId: options.collectionId,
+            boardId: options.boardId,
+            sectionId: options.boardSectionId,
             content
         });
 

--- a/test/handle_card.test.js
+++ b/test/handle_card.test.js
@@ -125,6 +125,7 @@ describe.each([
 
     it('updates the card', async() => {
         expect(client.getCalls()[1]).toEqual(updateCardApiCall({
+            preferredPhrase: 'Final',
             content: await resource('test_card_expected_output.html')
         }));
     });


### PR DESCRIPTION
Fixes #37.

Start updating card titles as well as content, in case it gets changed.
