### PR TITLE
Properly resolve image paths before checking them

### DIFF
--- a/src/core/build_content_tree.js
+++ b/src/core/build_content_tree.js
@@ -1,0 +1,23 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+
+export default async function(content, options = {}) {
+    const { logger, github, footer: footerTemplate } = options;
+
+    if(footerTemplate && typeof footerTemplate === 'string') {
+        const footer = footerTemplate.replaceAll('{{repository_url}}', github.repo.url);
+        content += '\n\n' + footer;
+    }
+    else {
+        logger.info('Skipping card footer...');
+    }
+
+    const mdastTree = unified()
+        .use(remarkParse)
+        .parse(content);
+
+    return await unified()
+        .use(remarkRehype)
+        .run(mdastTree);
+}

--- a/src/core/handle_card.js
+++ b/src/core/handle_card.js
@@ -16,9 +16,14 @@ export default async function(filePath, cardTitle, options) {
     // Extract the paths of referenced images from the Markdown file so that we can check whether they have changed.
     const imagePaths = analyzeTree(contentTree, { image: /img/ }).image
         .map(node => resolveLocalPath(node.properties.src, path.dirname(filePath)));
+    
+    const watchedFiles = [filePath, ...imagePaths];
+
+    logger.debug('Checking whether any of the following files have changed:');
+    watchedFiles.forEach((file) => logger.debug(`\t- ${file}`));
 
     // Check whether the Markdown file or any of its images have changed.
-    const changed = [filePath, ...imagePaths].some(file => didFileChange(file));
+    const changed = watchedFiles.some(file => didFileChange(file));
     
     const cardId = existingCardIds[filePath];
     if(cardId && !changed) {

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -1,3 +1,19 @@
+import path from 'path';
+
 export function base64(input) {
     return Buffer.from(input, 'utf8').toString('base64');
+}
+
+export function resolveLocalPath(url, parent) {
+    if(url.startsWith('/')) {
+        return url.substring(1);
+    }
+    if(url.startsWith('./')) {
+        return resolveUrl(url.substring(2));
+    }
+    if(url.startsWith('../')) {
+        return resolveUrl(url.substring(3), path.dirname((parent)));
+    }
+
+    return path.join(parent, url);
 }

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -9,10 +9,10 @@ export function resolveLocalPath(url, parent) {
         return url.substring(1);
     }
     if(url.startsWith('./')) {
-        return resolveUrl(url.substring(2));
+        return resolveLocalPath(url.substring(2));
     }
     if(url.startsWith('../')) {
-        return resolveUrl(url.substring(3), path.dirname((parent)));
+        return resolveLocalPath(url.substring(3), path.dirname((parent)));
     }
 
     return path.join(parent, url);

--- a/test/build_content.test.js
+++ b/test/build_content.test.js
@@ -1,9 +1,9 @@
-import runBuild from '../src/core/build_content.js';
+import buildContentTree from '../src/core/build_content_tree.js';
+import buildContent from '../src/core/build_content.js';
 import createApi from '../src/core/api.js';
 import nullLogger from './support/null_logger.js';
 import arrayLogger from './support/array_logger.js';
 import createClient from './support/api_client.js';
-import { apiCall } from './support/util.js';
 
 async function build(filePath, content, options = {}) {
     options.logger ||= nullLogger();
@@ -22,7 +22,8 @@ async function build(filePath, content, options = {}) {
         options.footer = '<{{repository_url}}>';
     }
 
-    return await runBuild(filePath, content, options);
+    const tree = await buildContentTree(content, options);
+    return await buildContent(filePath, tree, options);
 }
 
 describe('build_content.js', () => {

--- a/test/handle_card.test.js
+++ b/test/handle_card.test.js
@@ -309,6 +309,27 @@ describe('with unchanged file', () => {
 
         expect(client.getCalls().length).toBe(0);
     });
+
+    test.each([
+        ['test_card_with_local_image.md'],
+        ['test_card_with_local_parent_image.md'],
+        ['test_card_with_local_root_image.md'],
+    ])('with changed referenced image', async(card) => {
+        const client = createClient();
+
+        await handleCard({
+            client,
+            filePath: 'test/resources/' + card,
+            cardTitle: 'Test Card',
+            didFileChange: (file) => file === 'test/resources/empty.png',
+            inputs: {
+                collectionId: 'c123'
+            }
+        });
+
+        expect(client.getCalls().length).toBe(1);
+        expect(client.getCalls()[0].type).toBe('createCard');
+    });
 });
 
 test('with failed server JSON response throws proper error', async() => {

--- a/test/resources/test_card_with_local_parent_image.md
+++ b/test/resources/test_card_with_local_parent_image.md
@@ -1,0 +1,1 @@
+![local image](../resources/empty.png)


### PR DESCRIPTION
Before adding image paths to the list of files to watch for changes,
resolve them from the repository root.

In the process, split build_content into two distinct steps: one to
build the HAST tree and one to generate the final output.
