### PR TITLE
Allow no cards file

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "theguru",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/core/inputs.js
+++ b/src/core/inputs.js
@@ -51,7 +51,7 @@ export default function(getCoreInput, options) {
                 input('board_id');
                 input('board_section_id');
                 input('cards_file', b => b.try(b => b.boolean()).use(value => {
-                    if (value === null || value === true) {
+                    if(value === null || value === true) {
                         return result('uploaded-guru-cards.json');
                     }
                 }));

--- a/src/core/inputs.js
+++ b/src/core/inputs.js
@@ -50,7 +50,11 @@ export default function(getCoreInput, options) {
                 input('cards', b => b.required().json({ type: 'object' }));
                 input('board_id');
                 input('board_section_id');
-                input('cards_file', b => b.fallback('uploaded-guru-cards.json'));
+                input('cards_file', b => b.try(b => b.boolean()).use(value => {
+                    if (value === null || value === true) {
+                        return result('uploaded-guru-cards.json');
+                    }
+                }));
                 input('update_all', b => b.fallback('false').boolean());
             }
             else if(type === 'synced') {

--- a/src/core/standard/action.js
+++ b/src/core/standard/action.js
@@ -66,7 +66,7 @@ export default async function(options) {
     let cardsFileContent = '{}';
 
     // Read the cards file if it exists.
-    if(fs.existsSync(inputs.cardsFile)) {
+    if(inputs.cardsFile && fs.existsSync(inputs.cardsFile)) {
         cardsFileContent = await readFile(inputs.cardsFile);
     }
 
@@ -92,6 +92,12 @@ export default async function(options) {
         newCardIds[filePath] = id;
 
         logger.endGroup();
+    }
+
+    // Skip the cards file update if appropriate.
+    if (!inputs.cardsFile) {
+        logger.info(colors.blue('Skipping update of the cards file since "cards_file" is "false".'));
+        return;
     }
 
     // Get the cards that were present in the old cards file but not in the new one.

--- a/src/core/standard/action.js
+++ b/src/core/standard/action.js
@@ -95,7 +95,7 @@ export default async function(options) {
     }
 
     // Skip the cards file update if appropriate.
-    if (!inputs.cardsFile) {
+    if(!inputs.cardsFile) {
         logger.info(colors.blue('Skipping update of the cards file since "cards_file" is "false".'));
         return;
     }


### PR DESCRIPTION
Modify the standard action so that when cards_file is `false`, no cards
file is used. This will be useful for creation-only use-cases.
